### PR TITLE
Add support for array of simple values.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ gemspec
 gem "activesupport", "~> 6.1", ">= 6.1.4.1"
 gem "rake", "~> 13.0", ">= 13.0.6"
 gem "rspec-rails", "~> 5.0", ">= 5.0.2"
+gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-json_api (1.1.1)
+    rspec-json_api (1.2.0)
       activesupport (>= 6.1.4.1)
       rails (>= 6.1.4.1)
       rspec-rails (>= 5.0.2)
@@ -68,6 +68,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    ast (2.4.2)
+    base64 (0.1.1)
     builder (3.2.4)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
@@ -78,6 +80,8 @@ GEM
       activesupport (>= 6.1)
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
+    json (2.6.3)
+    language_server-protocol (3.17.0.3)
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -104,6 +108,10 @@ GEM
     nokogiri (1.13.1)
       mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
+    parallel (1.23.0)
+    parser (3.2.2.3)
+      ast (~> 2.4.1)
+      racc
     racc (1.6.0)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -134,7 +142,10 @@ GEM
       method_source
       rake (>= 0.13)
       thor (~> 1.0)
+    rainbow (3.1.1)
     rake (13.0.6)
+    regexp_parser (2.8.1)
+    rexml (3.2.6)
     rspec-core (3.10.2)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.2)
@@ -152,6 +163,21 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.3)
+    rubocop (1.56.3)
+      base64 (~> 0.1.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.3)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -163,6 +189,7 @@ GEM
     timeout (0.4.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (2.4.2)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -177,6 +204,7 @@ DEPENDENCIES
   rake (~> 13.0, >= 13.0.6)
   rspec-json_api!
   rspec-rails (~> 5.0, >= 5.0.2)
+  rubocop
 
 BUNDLED WITH
    2.2.19

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-json_api (1.2.0)
+    rspec-json_api (1.2.1)
       activesupport (>= 6.1.4.1)
       rails (>= 6.1.4.1)
       rspec-rails (>= 5.0.2)

--- a/lib/rspec/json_api/compare_array.rb
+++ b/lib/rspec/json_api/compare_array.rb
@@ -8,17 +8,13 @@ module RSpec
       def compare(actual, expected)
         if interface?(expected)
           actual.all? do |actual_elem|
-            # Compare actual and expected schema
             return false unless actual_elem.deep_keys == expected[0].deep_keys
 
             CompareHash.compare(actual_elem, expected[0])
           end
         else
           actual.each_with_index.all? do |actual_elem, index|
-            # Compare actual and expected schema
-            return false unless actual[index].deep_keys == expected[index].deep_keys
-
-            CompareHash.compare(actual_elem, expected[index])
+            compare_primitive_type_element(actual, expected, actual_elem, index)
           end
         end
       end
@@ -27,6 +23,16 @@ module RSpec
 
       def interface?(expected_value)
         expected_value.size == 1 && expected_value[0].is_a?(Hash)
+      end
+
+      def compare_primitive_type_element(actual, expected, actual_elem, index)
+        if actual[index].respond_to?(:deep_keys) && expected[index].respond_to?(:deep_keys)
+          return false unless actual[index].deep_keys == expected[index].deep_keys
+
+          CompareHash.compare(actual_elem, expected[index])
+        else
+          CompareHash.compare_values(actual[index], expected[index])
+        end
       end
     end
   end

--- a/lib/rspec/json_api/compare_hash.rb
+++ b/lib/rspec/json_api/compare_hash.rb
@@ -15,18 +15,16 @@ module RSpec
         compare_key_paths_and_values(keys, actual, expected)
       end
 
-      private
-
       def compare_key_paths_and_values(keys, actual, expected)
         keys.all? do |key_path|
           actual_value = actual.dig(*key_path)
           expected_value = expected.dig(*key_path)
 
-          compare_hash_values(actual_value, expected_value)
+          compare_values(actual_value, expected_value)
         end
       end
 
-      def compare_hash_values(actual_value, expected_value)
+      def compare_values(actual_value, expected_value)
         case expected_value
         when Class
           compare_class(actual_value, expected_value)
@@ -37,7 +35,7 @@ module RSpec
         when Array
           compare_array(actual_value, expected_value)
         else
-          compare_value(actual_value, expected_value)
+          compare_simple_value(actual_value, expected_value)
         end
       end
 
@@ -63,7 +61,7 @@ module RSpec
           when :type
             compare_class(actual_value, condition_value)
           when :value
-            compare_value(actual_value, condition_value)
+            compare_simple_value(actual_value, condition_value)
           when :inclusion
             condition_value.include?(actual_value)
           when :min
@@ -95,12 +93,12 @@ module RSpec
           return false if actual_value&.size != expected_value&.size
 
           expected_value.each_with_index.all? do |elem, index|
-            elem.is_a?(Hash) ? compare(actual_value[index], elem) : compare_value(actual_value[index], elem)
+            elem.is_a?(Hash) ? compare(actual_value[index], elem) : compare_simple_value(actual_value[index], elem)
           end
         end
       end
 
-      def compare_value(actual_value, expected_value)
+      def compare_simple_value(actual_value, expected_value)
         actual_value == expected_value
       end
 

--- a/lib/rspec/json_api/version.rb
+++ b/lib/rspec/json_api/version.rb
@@ -2,6 +2,6 @@
 
 module RSpec
   module JsonApi
-    VERSION = "1.2.0"
+    VERSION = "1.2.1"
   end
 end

--- a/spec/rspec/json_api/matchers/match_json_schema_spec.rb
+++ b/spec/rspec/json_api/matchers/match_json_schema_spec.rb
@@ -987,4 +987,30 @@ RSpec.describe "match_json_schema matcher" do
       end
     end
   end
+
+  context "when JSON schema is array of primitive types" do
+    context "when correct match" do
+      let(:actual) do
+        ["string", 1].to_json
+      end
+
+      let(:expected) do
+        ["string", 1]
+      end
+
+      include_examples "correct-match"
+    end
+
+    context "when incorrect match" do
+      let(:actual) do
+        ["string", 1].to_json
+      end
+
+      let(:expected) do
+        ["string2", 1]
+      end
+
+      include_examples "incorrect-match"
+    end
+  end
 end


### PR DESCRIPTION
Fixed:
- JSON payload containing array of primitive values no longer raises an error 